### PR TITLE
updating the lint config to be a bit more strict

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,6 +31,24 @@
     "@typescript-eslint/no-var-requires": 2,
     "@typescript-eslint/prefer-nullish-coalescing": 2,
     "@typescript-eslint/prefer-optional-chain": 2,
-    "@typescript-eslint/no-explicit-any": 2
+    "@typescript-eslint/no-explicit-any": 2,
+    "@typescript-eslint/consistent-type-definitions": ["error", "interface"],
+    "@typescript-eslint/no-confusing-non-null-assertion": 2,
+    "@typescript-eslint/no-require-imports": 2,
+    "camelcase": "off",
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        "selector": "memberLike",
+        "modifiers": ["private"],
+        "format": ["camelCase"],
+        "leadingUnderscore": "require"
+      },
+  
+      {
+        "selector": "typeLike",
+        "format": ["PascalCase"]
+      }
+    ]
   }
 }


### PR DESCRIPTION
as promised, types and interfaces will be required to be typed in `PascalCase
![Screen Shot 2022-07-03 at 9 34 16 PM](https://user-images.githubusercontent.com/73181383/177082187-b5bb48de-54c3-435d-8504-742e4973dad9.png)


should resolve #16 