### PR TITLE
config(automation): enable coverage reporting and report it to `codecov`

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -25,3 +25,5 @@ jobs:
       - run: npm run build --if-present
       - run: npm run lint
       - run: npm run test
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .env
+coverage

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,4 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-};
+}; 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "serve": "concurrently \"tsc --watch\" \"nodemon -q dist/index.js\"",
     "prestart": "npm run build",
     "start": "cross-env NODE_ENV=production node dist/index.js",
-    "test": "cross-env NODE_ENV=test jest --testTimeout=10000 --runInBand"
+    "test": "cross-env NODE_ENV=test jest --testTimeout=10000 --runInBand --coverage"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
this should allow us to get coverage reports from the bot. we _might_ need to add an auth token to this though.